### PR TITLE
Feature/load

### DIFF
--- a/Gravity Controller/Assets/Scenes/MainSettingUI.unity
+++ b/Gravity Controller/Assets/Scenes/MainSettingUI.unity
@@ -6944,10 +6944,7 @@ MonoBehaviour:
   - {fileID: 141143316}
   - {fileID: 773050754}
   - {fileID: 1361033028}
-  _defaultValues:
-  - 50
-  - 50
-  - 50
+  _defaultValues: 320000003200000032000000
 --- !u!4 &1497681282
 Transform:
   m_ObjectHideFlags: 0

--- a/Gravity Controller/Assets/Scenes/MainSettingUI.unity
+++ b/Gravity Controller/Assets/Scenes/MainSettingUI.unity
@@ -8067,7 +8067,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1853980352
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Gravity Controller/Assets/Scenes/MainSettingUI.unity
+++ b/Gravity Controller/Assets/Scenes/MainSettingUI.unity
@@ -615,6 +615,7 @@ RectTransform:
   - {fileID: 1403767873}
   - {fileID: 1352270212}
   - {fileID: 550464212}
+  - {fileID: 1236269402}
   m_Father: {fileID: 1117206318}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -709,15 +710,15 @@ MonoBehaviour:
   m_HandleRect: {fileID: 2111819190}
   m_Direction: 0
   m_MinValue: 0
-  m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 1
+  m_MaxValue: 100
+  m_WholeNumbers: 1
+  m_Value: 100
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: SlimUI.ModernMenu.UISettingsManager, Assembly-CSharp
-        m_MethodName: MusicSlider
+      - m_Target: {fileID: 1236269405}
+        m_TargetAssemblyTypeName: SliderPercentage, Assembly-CSharp
+        m_MethodName: UpdateText
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2812,6 +2813,99 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 723283173}
   m_CullTransparentMesh: 1
+--- !u!1 &740695663
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 740695664}
+  - component: {fileID: 740695666}
+  - component: {fileID: 740695665}
+  - component: {fileID: 740695667}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &740695664
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 740695663}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.000073423}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 773050755}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: -86, y: -19}
+  m_SizeDelta: {x: 150.4921, y: 66.995}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &740695665
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 740695663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.33962262, g: 0.33962262, b: 0.33962262, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: c4a4f38739b2f214285296818ef463ee, type: 3}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 5
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 50%
+--- !u!222 &740695666
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 740695663}
+  m_CullTransparentMesh: 1
+--- !u!114 &740695667
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 740695663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e75ee300469730b479630420c750a0f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &773050754
 GameObject:
   m_ObjectHideFlags: 0
@@ -2838,13 +2932,14 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 773050754}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1307815997}
   - {fileID: 1080525823}
   - {fileID: 221223417}
+  - {fileID: 740695664}
   m_Father: {fileID: 1117206318}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2939,15 +3034,15 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1594511997}
   m_Direction: 0
   m_MinValue: 0
-  m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 1
+  m_MaxValue: 100
+  m_WholeNumbers: 1
+  m_Value: 100
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: SlimUI.ModernMenu.UISettingsManager, Assembly-CSharp
-        m_MethodName: MusicSlider
+      - m_Target: {fileID: 740695667}
+        m_TargetAssemblyTypeName: SliderPercentage, Assembly-CSharp
+        m_MethodName: UpdateText
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -5529,6 +5624,99 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1191147310}
   m_CullTransparentMesh: 1
+--- !u!1 &1236269401
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1236269402}
+  - component: {fileID: 1236269404}
+  - component: {fileID: 1236269403}
+  - component: {fileID: 1236269405}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1236269402
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1236269401}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.000082736195}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 141143317}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: -86.00012, y: -18.509964}
+  m_SizeDelta: {x: 150.4921, y: 66.995}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1236269403
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1236269401}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.33962262, g: 0.33962262, b: 0.33962262, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: c4a4f38739b2f214285296818ef463ee, type: 3}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 5
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 50%
+--- !u!222 &1236269404
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1236269401}
+  m_CullTransparentMesh: 1
+--- !u!114 &1236269405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1236269401}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e75ee300469730b479630420c750a0f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1256913993
 GameObject:
   m_ObjectHideFlags: 0
@@ -6068,6 +6256,7 @@ RectTransform:
   - {fileID: 1303085837}
   - {fileID: 2084692978}
   - {fileID: 33805673}
+  - {fileID: 1990427917}
   m_Father: {fileID: 1117206318}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6162,15 +6351,15 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1547549890}
   m_Direction: 0
   m_MinValue: 0
-  m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 1
+  m_MaxValue: 100
+  m_WholeNumbers: 1
+  m_Value: 100
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: SlimUI.ModernMenu.UISettingsManager, Assembly-CSharp
-        m_MethodName: MusicSlider
+      - m_Target: {fileID: 1990427920}
+        m_TargetAssemblyTypeName: SliderPercentage, Assembly-CSharp
+        m_MethodName: UpdateText
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -6571,7 +6760,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: sensitivity
+  m_Text: mouse sensitivity
 --- !u!222 &1480439340
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -6751,6 +6940,14 @@ MonoBehaviour:
   - {fileID: 1117206317}
   - {fileID: 179217887}
   - {fileID: 1727846444}
+  _sliders:
+  - {fileID: 141143316}
+  - {fileID: 773050754}
+  - {fileID: 1361033028}
+  _defaultValues:
+  - 50
+  - 50
+  - 50
 --- !u!4 &1497681282
 Transform:
   m_ObjectHideFlags: 0
@@ -8843,6 +9040,99 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1990427916
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1990427917}
+  - component: {fileID: 1990427919}
+  - component: {fileID: 1990427918}
+  - component: {fileID: 1990427920}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1990427917
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990427916}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.000082736195}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1361033029}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: -86, y: -19}
+  m_SizeDelta: {x: 150.4921, y: 66.995}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1990427918
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990427916}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.33962262, g: 0.33962262, b: 0.33962262, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: c4a4f38739b2f214285296818ef463ee, type: 3}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 5
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 50%
+--- !u!222 &1990427919
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990427916}
+  m_CullTransparentMesh: 1
+--- !u!114 &1990427920
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990427916}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e75ee300469730b479630420c750a0f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2074340059
 GameObject:
   m_ObjectHideFlags: 0

--- a/Gravity Controller/Assets/Scripts/FileManager.cs
+++ b/Gravity Controller/Assets/Scripts/FileManager.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public static class FileManager
+{
+	public static bool WriteToFile(string a_FileName, string a_FileContents)
+	{
+		var fullPath = Path.Combine(Application.persistentDataPath, a_FileName);
+
+		try
+		{
+			File.WriteAllText(fullPath, a_FileContents);
+			return true;
+		}
+		catch (Exception e)
+		{
+			Debug.LogError($"Failed to write to {fullPath} with exception {e}");
+			return false;
+		}
+	}
+
+	public static bool LoadFromFile(string a_FileName, out string result)
+	{
+		var fullPath = Path.Combine(Application.persistentDataPath, a_FileName);
+
+		try
+		{
+			result = File.ReadAllText(fullPath);
+			return true;
+		}
+		catch (Exception e)
+		{
+			Debug.LogError($"Failed to read from {fullPath} with exception {e}");
+			result = "";
+			return false;
+		}
+	}
+}
+
+// Source: https://github.com/UnityTechnologies/UniteNow20-Persistent-Data?tab=MIT-1-ov-file
+
+/*
+MIT License
+
+Copyright (c) 2020 Bronson Zgeb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */

--- a/Gravity Controller/Assets/Scripts/FileManager.cs.meta
+++ b/Gravity Controller/Assets/Scripts/FileManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8df577bac2110cd42bad58a492a9c471
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Gravity Controller/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Gravity Controller/Assets/Scripts/Player/PlayerMovement.cs
@@ -27,7 +27,7 @@ public class PlayerMovement : MonoBehaviour
     public float sensetivityX;
     public float sensetivityY;
 	[SerializeField] private KeyCode _viewResetKey;
-	private float _sensitivityMultiplier;
+	private float _sensitivityMultiplier = 0.5f;
 	[SerializeField] private float _sensitivityMultiplierMin = 0.5f;
 	[SerializeField] private float _sensitivityMultiplierMax = 1.5f;
 

--- a/Gravity Controller/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Gravity Controller/Assets/Scripts/Player/PlayerMovement.cs
@@ -27,6 +27,9 @@ public class PlayerMovement : MonoBehaviour
     public float sensetivityX;
     public float sensetivityY;
 	[SerializeField] private KeyCode _viewResetKey;
+	private float _sensitivityMultiplier;
+	[SerializeField] private float _sensitivityMultiplierMin = 0.5f;
+	[SerializeField] private float _sensitivityMultiplierMax = 1.5f;
 
     // determine camera rotation
     private float _accumRotationX = 0;
@@ -78,9 +81,9 @@ public class PlayerMovement : MonoBehaviour
 
         // player rotation
         transform.eulerAngles = new Vector3(0, _accumRotationX, 0);
-        _accumRotationX += Time.deltaTime * _mouseInputX * sensetivityX;
+        _accumRotationX += Time.deltaTime * _mouseInputX * sensetivityX * _sensitivityMultiplier;
         // camera rotation
-        _accumRotationY += Time.deltaTime * _mouseInputY * sensetivityY;
+        _accumRotationY += Time.deltaTime * _mouseInputY * sensetivityY * _sensitivityMultiplier;
         _accumRotationY = Math.Clamp(_accumRotationY, -_rotationLimitY, _rotationLimitY);
 
         _camera.transform.eulerAngles = new Vector3(-_accumRotationY, _accumRotationX, 0);
@@ -145,4 +148,9 @@ public class PlayerMovement : MonoBehaviour
     //         _isGrounded = true;
     //     }
     // }
+
+	public void SetSensitivityMultiplier(int percentage)
+	{
+		_sensitivityMultiplier = _sensitivityMultiplierMin + (_sensitivityMultiplierMax - _sensitivityMultiplierMin) * ((float)percentage) / 100;
+	}
 }

--- a/Gravity Controller/Assets/Scripts/Save.meta
+++ b/Gravity Controller/Assets/Scripts/Save.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1388ac5bb579fd3429e730d4d35ace14
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Gravity Controller/Assets/Scripts/Save/Autosave.cs
+++ b/Gravity Controller/Assets/Scripts/Save/Autosave.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Autosave
+{
+	public static void SaveGameSave(bool atLobby, int stage)
+	{
+		var save = new GameSave();
+		save.atLobby = atLobby;
+		save.stage = stage;
+
+		FileManager.WriteToFile("settings.dat", JsonUtility.ToJson(save));
+	}
+}

--- a/Gravity Controller/Assets/Scripts/Save/Autosave.cs.meta
+++ b/Gravity Controller/Assets/Scripts/Save/Autosave.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d0f660633af0384ebc9d96a42fcf1e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Gravity Controller/Assets/Scripts/Save/GameSave.cs
+++ b/Gravity Controller/Assets/Scripts/Save/GameSave.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+[SerializeField]
+public class GameSave
+{
+	public int progress;
+	public static GameSave Restore(string json)
+	{
+		// reverts JSON string
+		try
+		{
+			var save = JsonUtility.FromJson<GameSave>(json);
+			return save;
+		}
+		catch
+		{
+			return null;
+		}
+	}
+}

--- a/Gravity Controller/Assets/Scripts/Save/GameSave.cs
+++ b/Gravity Controller/Assets/Scripts/Save/GameSave.cs
@@ -3,7 +3,8 @@ using UnityEngine;
 [SerializeField]
 public class GameSave
 {
-	public int progress;
+	public bool atLobby;
+	public int stage;
 	public static GameSave Restore(string json)
 	{
 		// reverts JSON string
@@ -16,5 +17,10 @@ public class GameSave
 		{
 			return null;
 		}
+	}
+	
+	public bool HasProgressed()
+	{
+		return (atLobby == true) || (stage > 1);
 	}
 }

--- a/Gravity Controller/Assets/Scripts/Save/GameSave.cs.meta
+++ b/Gravity Controller/Assets/Scripts/Save/GameSave.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d8c9630223563f4895a6c530ba38918
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Gravity Controller/Assets/Scripts/Save/SettingsSave.cs
+++ b/Gravity Controller/Assets/Scripts/Save/SettingsSave.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+[SerializeField]
+public class SettingsSave
+{
+	public float backGroundVolume;
+	public float effectVolume;
+	public float sensitivity;
+
+	public static SettingsSave Restore(string json)
+	{
+		// reverts JSON string
+		try
+		{
+			var save = JsonUtility.FromJson<SettingsSave>(json);
+			return save;
+		}
+		catch
+		{
+			return null;
+		} 
+	}
+}

--- a/Gravity Controller/Assets/Scripts/Save/SettingsSave.cs
+++ b/Gravity Controller/Assets/Scripts/Save/SettingsSave.cs
@@ -3,9 +3,9 @@ using UnityEngine;
 [SerializeField]
 public class SettingsSave
 {
-	public float backGroundVolume;
-	public float effectVolume;
-	public float sensitivity;
+	public int backGroundVolume;
+	public int effectVolume;
+	public int sensitivity;
 
 	public static SettingsSave Restore(string json)
 	{

--- a/Gravity Controller/Assets/Scripts/Save/SettingsSave.cs.meta
+++ b/Gravity Controller/Assets/Scripts/Save/SettingsSave.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82d9e7351a0e182469657eece2cfa0ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Gravity Controller/Assets/Scripts/UI/CanvasSwitcher.cs
+++ b/Gravity Controller/Assets/Scripts/UI/CanvasSwitcher.cs
@@ -14,6 +14,7 @@ public class CanvasSwitcher : MonoBehaviour
 	public GameObject[] panels; // 버튼과 연결된 패널들을 배열로 저장.
 
 	public SettingsSave settingsSave = null;
+	public GameSave gameSave = null;
 
 	[SerializeField] private GameObject[] _sliders;
 	[SerializeField] private int[] _defaultValues;
@@ -34,6 +35,8 @@ public class CanvasSwitcher : MonoBehaviour
 	{
 		// Load settings
 		LoadSettingsSave();
+
+		LoadGameSave();
 	}
 
 	// 버튼 클릭 시 호출되는 함수
@@ -138,6 +141,32 @@ public class CanvasSwitcher : MonoBehaviour
 		settingsSave.effectVolume = Percentify.Convert(save.effectVolume);
 		settingsSave.sensitivity = Percentify.Convert(save.sensitivity);
 	}
+
+	private void LoadGameSave()
+	{
+		string json;
+		if (!FileManager.LoadFromFile("save.dat", out json))
+		{
+			// No file; Set to default
+			gameSave.atLobby = false;
+			gameSave.stage = 1;
+			return;
+		}
+		var save = GameSave.Restore(json);
+		if (save == null)
+		{
+			// Invalid file; Set to default
+			Debug.Log("Invalid file: " + "save.dat");
+			gameSave.atLobby = false;
+			gameSave.stage = 1;
+			return;
+		}
+
+		gameSave = new GameSave();
+		gameSave.atLobby = save.atLobby;
+		gameSave.stage = (save.stage < 1) ? 1 : (save.stage > 4) ? 4 : save.stage;
+	}
+
 	private void SaveSettingsSave()
 	{
 		var save = new SettingsSave();

--- a/Gravity Controller/Assets/Scripts/UI/CanvasSwitcher.cs
+++ b/Gravity Controller/Assets/Scripts/UI/CanvasSwitcher.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 
 public class CanvasSwitcher : MonoBehaviour
 {
@@ -8,6 +10,9 @@ public class CanvasSwitcher : MonoBehaviour
 	public CanvasGroup newCanvas; // 활성화할 새로운 캔버스
 	public float fadeDuration = 0.5f; // 페이드 효과 지속 시간
 	public GameObject[] panels; // 버튼과 연결된 패널들을 배열로 저장.
+
+	[SerializeField] private GameObject[] _sliders;
+	[SerializeField] private float[] _defaultValues;
 
 	// 버튼 클릭 시 호출되는 함수
 	public void ShowPanel(int index)
@@ -28,12 +33,16 @@ public class CanvasSwitcher : MonoBehaviour
 	// 캔버스를 스위치하는 첫 번째 버튼 함수
 	public void SwitchToNewCanvas()
 	{
+		// Load settings
+		LoadSettingsSave();
 		StartCoroutine(FadeOutAndIn(currentCanvas, newCanvas));
 	}
 
 	// 캔버스를 스위치하는 두 번째 버튼 함수
 	public void SwitchToCurrentCanvas()
 	{
+		// Save settings
+		SaveSettingsSave();
 		StartCoroutine(FadeOutAndIn(newCanvas, currentCanvas));
 	}
 
@@ -83,5 +92,48 @@ public class CanvasSwitcher : MonoBehaviour
 		}
 
 		canvasGroup.alpha = 1f; // 페이드 인 완료
+	}
+
+	private void LoadSettingsSave()
+	{
+		string json;
+		if (!FileManager.LoadFromFile("settings.dat", out json))
+		{
+			// No file; Set to default
+			SetSliders(_defaultValues);
+			return;
+		}
+		var settingsSave = SettingsSave.Restore(json);
+		if(settingsSave == null)
+		{
+			// Invalid file; Set to default
+			Debug.Log("Invalid file: " + "settings.dat");
+			SetSliders(_defaultValues);
+			return;
+		}
+		var values = new float[3];
+		values[0] = settingsSave.backGroundVolume;
+		values[1] = settingsSave.effectVolume;
+		values[2] = settingsSave.sensitivity;
+		SetSliders(values);
+	}
+	private void SaveSettingsSave()
+	{
+		var save = new SettingsSave();
+		save.backGroundVolume = _sliders[0].GetComponent<Slider>().value;
+		save.effectVolume = _sliders[1].GetComponent<Slider>().value;
+		save.sensitivity = _sliders[2].GetComponent<Slider>().value;
+
+		FileManager.WriteToFile("settings.dat", JsonUtility.ToJson(save));
+	}
+
+	private void SetSliders(float[] values)
+	{
+		for(int i=0; i< values.Length; i++)
+		{
+			if (values[i] < 0) values[i] = 0;
+			if (values[i] > 100) values[i] = 100;
+			_sliders[i].GetComponent<Slider>().value = values[i];
+		}
 	}
 }

--- a/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
+++ b/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
@@ -12,6 +12,58 @@ public class SceneChangeHandler : MonoBehaviour
 
 	public void LoadGame(string scene)
 	{
-		SceneManager.LoadScene(scene);
+		StartCoroutine(LoadGameCoroutine(scene));
+	}
+
+	public void ContinueGame(string scene)
+	{
+		string json;
+		if (!FileManager.LoadFromFile("save.dat", out json))
+		{
+			// TODO alert
+			return;
+		}
+
+		StartCoroutine(ContinueGameCoroutine(scene));
+	}
+
+	private void InitGameSave()
+	{
+		// TODO Initial settings
+	}
+
+	private void InitSettingsSave()
+	{
+		// TODO Initial settings
+		var settingsSave = CanvasSwitcher.Instance.settingsSave;
+		var player = GameObject.Find("Player");
+		player.GetComponent<PlayerMovement>().SetSensitivityMultiplier(settingsSave.sensitivity);
+	}
+
+	IEnumerator LoadGameCoroutine(string scene)
+	{
+		AsyncOperation asyncLoad = SceneManager.LoadSceneAsync(scene, LoadSceneMode.Additive);
+		while (!asyncLoad.isDone)
+		{
+			yield return null;
+		}
+		var mainMenu = SceneManager.GetActiveScene();
+		SceneManager.SetActiveScene(SceneManager.GetSceneByName(scene));
+		InitSettingsSave();
+		SceneManager.UnloadSceneAsync(mainMenu);
+	}
+
+	IEnumerator ContinueGameCoroutine(string scene)
+	{
+		AsyncOperation asyncLoad = SceneManager.LoadSceneAsync(scene, LoadSceneMode.Additive);
+		while (!asyncLoad.isDone)
+		{
+			yield return null;
+		}
+		var mainMenu = SceneManager.GetActiveScene();
+		SceneManager.SetActiveScene(SceneManager.GetSceneByName(scene));
+		InitGameSave();
+		InitSettingsSave();
+		SceneManager.UnloadSceneAsync(mainMenu);
 	}
 }

--- a/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
+++ b/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
@@ -12,14 +12,21 @@ public class SceneChangeHandler : MonoBehaviour
 
 	public void LoadGame(string scene)
 	{
+		if (CanvasSwitcher.Instance.gameSave.HasProgressed())
+		{
+			// savefile exists
+			// TODO alert
+			return;
+		}
+		
 		StartCoroutine(LoadGameCoroutine(scene));
 	}
 
 	public void ContinueGame(string scene)
 	{
-		string json;
-		if (!FileManager.LoadFromFile("save.dat", out json))
+		if (!CanvasSwitcher.Instance.gameSave.HasProgressed())
 		{
+			// save is empty
 			// TODO alert
 			return;
 		}
@@ -30,6 +37,23 @@ public class SceneChangeHandler : MonoBehaviour
 	private void InitGameSave()
 	{
 		// TODO Initial settings
+		var gameSave = CanvasSwitcher.Instance.gameSave;
+		var player = GameObject.Find("Player");
+		GameObject summonPoint = null;
+		if (gameSave.atLobby) { 
+			summonPoint = GameObject.Find("Summon Point").transform.GetChild(0).gameObject;
+		}
+		else {
+			summonPoint = GameObject.Find("Summon Point").transform.GetChild(1).GetChild(gameSave.stage - 1).gameObject;
+		}
+		player.transform.position = summonPoint.transform.position;
+		player.transform.rotation = summonPoint.transform.rotation;
+
+		// deactivate spawners
+		// activate cores -- _coreLight.enabled, RestoreCore
+		// light
+		// unlock doors
+		// unlock abilities
 	}
 
 	private void InitSettingsSave()

--- a/Gravity Controller/Assets/Scripts/UI/SliderPercentage.cs
+++ b/Gravity Controller/Assets/Scripts/UI/SliderPercentage.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SliderPercentage : MonoBehaviour
+{
+    public void UpdateText()
+	{
+		GetComponent<Text>().text = transform.parent.GetComponent<Slider>().value + "%";
+	}
+}

--- a/Gravity Controller/Assets/Scripts/UI/SliderPercentage.cs.meta
+++ b/Gravity Controller/Assets/Scripts/UI/SliderPercentage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e75ee300469730b479630420c750a0f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# PR Title [Save and Load settings/game]

## Related Issue(s)
#64 페이드 인 시 버튼 비활성
 
## PR Description
환경설정/게임 진행도를 파일로 저장하고 불러오는 기능을 추가했습니다.
저장된 게임을 불러오는 부분은 아직 완성되지 않았습니다. (Scene 통합 작업 병합 후 작업 예정)

환경설정의 슬라이더를 수정했습니다. 백분율을 숫자로 보여주고, 슬라이더의 값은 0도 100까지의 정수값을 가집니다.

### Changes Included- [ 5 ] Added new feature(s)- [ 1 ] Fixed identified bug(s)- [ ] Updated relevant documentation

### Screenshots (if UI changes were made)
![image](https://github.com/user-attachments/assets/a239b080-e7cb-4b0e-9e4e-d4bfbe95824c)

### Notes for Reviewer
자세한 내용은 커밋 메시지 참고 바랍니다.
#64 의 문제는 본 브랜치에서의 개발 과정에서 발생했을 가능성이 있습니다. (현재는 수정했으므로 상관없음)

## Reviewer Checklist
- [x] Code is written in clean, maintainable, and idiomatic form.
- [x] Automated test coverage is adequate.
- [x] All existing tests pass.
- [x] Manual testing has been performed to ensure the PR works as expected.
- [x] Code review comments have been addressed or clarified.
