### PR TITLE
Hit effect by color panel, Fix Game over scene fonts

### DIFF
--- a/Gravity Controller/Assets/Scenes/GameOverScene.unity
+++ b/Gravity Controller/Assets/Scenes/GameOverScene.unity
@@ -194,7 +194,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 800, y: 600}
@@ -292,7 +292,7 @@ RectTransform:
   m_GameObject: {fileID: 348357796}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 931821449}
@@ -325,7 +325,7 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: 0d321ad12fe3d4391b506737af0972d1, type: 3}
-    m_FontSize: 14
+    m_FontSize: 28
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 1
@@ -333,8 +333,8 @@ MonoBehaviour:
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: RESTART
 --- !u!222 &348357799
@@ -757,7 +757,7 @@ RectTransform:
   m_GameObject: {fileID: 1523071654}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1652682020}
@@ -790,16 +790,16 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: 0d321ad12fe3d4391b506737af0972d1, type: 3}
-    m_FontSize: 14
+    m_FontSize: 28
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
+    m_MinSize: 2
     m_MaxSize: 40
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: MAIN MENU
 --- !u!222 &1523071657
@@ -1118,7 +1118,7 @@ RectTransform:
   m_GameObject: {fileID: 1898170313}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 41621821}
@@ -1151,16 +1151,16 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: 0d321ad12fe3d4391b506737af0972d1, type: 3}
-    m_FontSize: 20
+    m_FontSize: 60
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 0
-    m_MaxSize: 55
+    m_MaxSize: 60
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: GAME OVER
 --- !u!222 &1898170316

--- a/Gravity Controller/Assets/Scripts/Player/PlayerController.cs
+++ b/Gravity Controller/Assets/Scripts/Player/PlayerController.cs
@@ -340,6 +340,7 @@ public class PlayerController : MonoBehaviour
 		_audioSource.PlayOneShot(_hitSound);
 		_currentHP--;
         UIManager.Instance.UpdateHP(_currentHP, _maxHP);
+        UIManager.Instance.ColorPanelEffect(Color.red);
         if(_currentHP <= 0) {
             _isAlive = false;
 			SceneManager.LoadScene("GameOverScene");

--- a/Gravity Controller/Assets/Scripts/UI/UIManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/UIManager.cs
@@ -11,7 +11,6 @@ public class UIManager : MonoBehaviour
 
 	[Header("HP")]
 	[SerializeField] private List<Image> _hpSegments;
-	[SerializeField] private float _hpBarDamping;
 
 	[Header("Energy")]
 	[SerializeField] private Image _energyGauge;
@@ -24,6 +23,12 @@ public class UIManager : MonoBehaviour
 	[SerializeField] private RectTransform _crossHair;
 	[SerializeField] private float _defaultSize = 100f;
 	[SerializeField] private float _fireSize = 200f;
+	
+	[Header("Color Panel")]
+	[SerializeField] private Image _colorPanel;
+	[SerializeField] private float _colorPanelEffectDuration;
+	[SerializeField] private float _colorPanelEffectAlpha;
+	private float _colorPanelEffectTimer = 0f;
 
 	[Header("Core Interaction")]
 	[SerializeField] private GameObject _warningTriangle;
@@ -111,7 +116,6 @@ public class UIManager : MonoBehaviour
 		}
 	}
 
-
 	private IEnumerator PlayFullEnergyEffect()
 	{
 		float effectDuration = 1f;
@@ -127,6 +131,21 @@ public class UIManager : MonoBehaviour
 		}
 
 		_energyGauge.color = new Color(75 / 255f, 0, 130 / 255f);
+	}
+
+	public void ColorPanelEffect(Color color) {
+		_colorPanelEffectTimer = 0;
+		StartCoroutine(ColorPanelEffectCoroutine(color));
+	}
+
+	private IEnumerator ColorPanelEffectCoroutine(Color color) {
+		float t = 0;
+		while(t < 1) {
+			t = _colorPanelEffectTimer / _colorPanelEffectDuration;
+			_colorPanel.color = new Color(color.r, color.g, color.b, color.a * (1 - t) * _colorPanelEffectAlpha);
+			_colorPanelEffectTimer += Time.deltaTime;
+			yield return null;
+		}
 	}
 
 	public void UpdateBullet(int currentBullet, int maxBullet)


### PR DESCRIPTION
# PR Title [Descriptive title summarizing the change]
Hit effect by color panel, Fix Game over scene fonts

## PR Description
패널 ui를 사용해 피격 시 화면이 잠시 붉어지는 효과 추가
해당 효과는 색을 바꾸어 다른 순간에도 사용 가능함
게임 오버 씬의 폰트 깨짐 현상 해결
 
### Changes Included- [ ] Added new feature(s)- [ ] Fixed identified bug(s)- [ ] Updated relevant documentation

### Screenshots (if UI changes were made)
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/f6cc8d4c-12e7-44a9-af14-7d46bb5e65ea" />
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/b132a06f-b061-4676-8d8b-2536886c0052" />

### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.--

## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

## Additional Comments
Add any other comments or information that might be useful for the review process.
