### PR TITLE
volume manipulation

### DIFF
--- a/Gravity Controller/Assets/Scripts/Enemy/FlyingEnemy.cs
+++ b/Gravity Controller/Assets/Scripts/Enemy/FlyingEnemy.cs
@@ -89,6 +89,10 @@ public class FlyingEnemy : MonoBehaviour, IEnemy, ISkillReceiver, IAttackReceive
 	[SerializeField] private AudioClip _followingSound;
 	[SerializeField] private AudioClip _attackingSound;
 
+	[SerializeField] private float _flyingSoundMaxVolume = 1f;
+	[SerializeField] private float _followingSoundMaxVolume = 1f;
+	[SerializeField] private float _attackingSoundMaxVolume = 1f;
+
 	public EnemyState State { get; private set; }
 
 	void Awake()
@@ -114,6 +118,7 @@ public class FlyingEnemy : MonoBehaviour, IEnemy, ISkillReceiver, IAttackReceive
 		{
 			_audioSource.clip = _flyingSound;
 			_audioSource.loop = true;
+			_audioSource.volume = _flyingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 			_audioSource.Play();
 		}
 	}
@@ -197,6 +202,7 @@ public class FlyingEnemy : MonoBehaviour, IEnemy, ISkillReceiver, IAttackReceive
 						State = EnemyState.Follow;
 						if (_audioSource != null && _followingSound != null)
 						{
+							_audioSource.volume = _followingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 							_audioSource.PlayOneShot(_followingSound);
 						}
 						ChasePlayer();
@@ -411,6 +417,7 @@ public class FlyingEnemy : MonoBehaviour, IEnemy, ISkillReceiver, IAttackReceive
 
 		Vector3 directionToPlayer = (_player.transform.position - _gun.GetChild(0).position).normalized;
 
+		_audioSource.volume = _attackingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_attackingSound);
 
 		// proj.transform.rotation = Quaternion.LookRotation(directionToPlayer);

--- a/Gravity Controller/Assets/Scripts/Enemy/TurretEnemy.cs
+++ b/Gravity Controller/Assets/Scripts/Enemy/TurretEnemy.cs
@@ -81,6 +81,10 @@ public class TurretEnemy : MonoBehaviour, IEnemy, ISkillReceiver
 	[SerializeField] private AudioClip _chargingSound;
 	[SerializeField] private AudioClip _attackingSound;
 
+	[SerializeField] private float _workingSoundMaxVolume = 1f;
+	[SerializeField] private float _chargingSoundMaxVolume = 1f;
+	[SerializeField] private float _attackingSoundMaxVolume = 1f;
+
 	private bool _isCharging = false;
 	private bool _headDetached = false;
 	private bool _isRestoring = false;
@@ -131,6 +135,7 @@ public class TurretEnemy : MonoBehaviour, IEnemy, ISkillReceiver
 
 		_audioSource.clip = _workingSound;
 		_audioSource.loop = true;
+		_audioSource.volume = _workingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.Play();
 
 		_centralRotation = _column.rotation;
@@ -334,6 +339,7 @@ public class TurretEnemy : MonoBehaviour, IEnemy, ISkillReceiver
 	}
 
 	private IEnumerator ChargeAndFire() {
+		_audioSource.volume = _chargingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_chargingSound);
 		yield return new WaitForSeconds(_chargeTime);
 
@@ -356,6 +362,7 @@ public class TurretEnemy : MonoBehaviour, IEnemy, ISkillReceiver
 
 		Vector3 directionToPlayer = _column.rotation * new Vector3(0, 0, 1);
 
+		_audioSource.volume = _attackSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_attackingSound);
 
 		// proj.transform.rotation = Quaternion.LookRotation(directionToPlayer);

--- a/Gravity Controller/Assets/Scripts/Enemy/TurretEnemy.cs
+++ b/Gravity Controller/Assets/Scripts/Enemy/TurretEnemy.cs
@@ -362,7 +362,7 @@ public class TurretEnemy : MonoBehaviour, IEnemy, ISkillReceiver
 
 		Vector3 directionToPlayer = _column.rotation * new Vector3(0, 0, 1);
 
-		_audioSource.volume = _attackSoundMaxVolume * GameManager.Instance.GetSFXVolume();
+		_audioSource.volume = _attackingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_attackingSound);
 
 		// proj.transform.rotation = Quaternion.LookRotation(directionToPlayer);

--- a/Gravity Controller/Assets/Scripts/Enemy/WalkingEnemy.cs
+++ b/Gravity Controller/Assets/Scripts/Enemy/WalkingEnemy.cs
@@ -53,6 +53,10 @@ public class WalkingEnemy : MonoBehaviour, IEnemy, IAttackReceiver
 	[SerializeField] private AudioClip _followingSound;
 	[SerializeField] private AudioClip _attackingSound;
 
+	[SerializeField] private float _walkingSoundMaxVolume = 1f;
+	[SerializeField] private float _followingSoundMaxVolume = 1f;
+	[SerializeField] private float _attackingSoundMaxVolume = 1f;
+
 	public EnemyState State { get; private set; }
 
 	void Awake()
@@ -70,6 +74,7 @@ public class WalkingEnemy : MonoBehaviour, IEnemy, IAttackReceiver
 
 		_audioSource.clip = _walkingSound;
 		_audioSource.loop = true;
+		_audioSource.volume = _walkingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.Play();
 
 		SetRandomDirection();
@@ -147,6 +152,7 @@ public class WalkingEnemy : MonoBehaviour, IEnemy, IAttackReceiver
 					{
 						// Aware -> Follow
 						State = EnemyState.Follow;
+						_audioSource.volume = _followingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 						_audioSource.PlayOneShot(_followingSound);
 						Follow();
 						break;
@@ -296,6 +302,7 @@ public class WalkingEnemy : MonoBehaviour, IEnemy, IAttackReceiver
 
 	// fix: player controller가 유효한지 검사하는 과정 삭제
 	public void AttackHitCheck() {
+		_audioSource.volume = _attackingSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_attackingSound);
 		if (_attackSuccess)
 		{

--- a/Gravity Controller/Assets/Scripts/Environment/ClearCore.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/ClearCore.cs
@@ -17,6 +17,7 @@ public class ClearCore : MonoBehaviour, IInteractable
 
 	[SerializeField] private AudioSource _audioSource;
 	[SerializeField] private AudioClip _coreSound;
+	[SerializeField] private float _coreSoundMaxVolume = 1f;
 
 	void Start()
 	{
@@ -120,6 +121,7 @@ public class ClearCore : MonoBehaviour, IInteractable
 
 			if (_audioSource != null && _coreSound != null)
 			{
+				_audioSource.volume = _coreSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 				_audioSource.PlayOneShot(_coreSound);
 			}
 		}

--- a/Gravity Controller/Assets/Scripts/Environment/CoreController.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/CoreController.cs
@@ -32,6 +32,9 @@ public class CoreController : MonoBehaviour, IInteractable
 	[SerializeField] private AudioClip _lightSound;
 	[SerializeField] private AudioClip _coreSound;
 
+	[SerializeField] private float _lightSoundMaxVolume = 1f;
+	[SerializeField] private float _coreSoundMaxVolume = 1f;
+
 	// Start is called before the first frame update
 	void Start()
     {
@@ -49,6 +52,7 @@ public class CoreController : MonoBehaviour, IInteractable
     public void Interactive() {
         if(_isInteractable) {
 			_isInteractable = false;
+			_audioSource.volume = _lightSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 			_audioSource.PlayOneShot(_lightSound);
 			StartCoroutine(GlobalLightOn());
         }
@@ -96,6 +100,7 @@ public class CoreController : MonoBehaviour, IInteractable
         }
         _batteries[stage].materials[1] = _blueEmission;
         _batteryLights[stage].intensity = _batteryLightIntensity;
+		_audioSource.volume = _coreSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_coreSound);
 	}
     public bool IsInteractable()

--- a/Gravity Controller/Assets/Scripts/Environment/CoreInteraction.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/CoreInteraction.cs
@@ -35,6 +35,7 @@ public class CoreInteraction : MonoBehaviour, IInteractable
 	[Header("Audio")]
 	[SerializeField] private AudioSource _audioSource;
 	[SerializeField] private AudioClip _timeOutSound;
+	[SerializeField] private float _timeOutSoundMaxVolume = 1f;
 
 	void Start()
    {
@@ -98,7 +99,7 @@ public class CoreInteraction : MonoBehaviour, IInteractable
    private System.Collections.IEnumerator ClearEnemiesAndActivateEmission()
    {
       yield return new WaitForSeconds(_delay);
-
+		_audioSource.volume = _timeOutSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_timeOutSound);
 
 		SendOnDeathSignalToEnemies();	  

--- a/Gravity Controller/Assets/Scripts/Environment/Door/Door_2.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/Door/Door_2.cs
@@ -16,6 +16,7 @@ public class Door_2 : MonoBehaviour, IDoor
 
 	[SerializeField] private AudioSource _audioSource;
 	[SerializeField] private AudioClip _doorSound;
+	[SerializeField] private float _doorSoundMaxVolume = 1f;
 
 	void Start()
     {
@@ -57,6 +58,7 @@ public class Door_2 : MonoBehaviour, IDoor
         if(_isOpened) {
             return;
         }
+		_audioSource.volume = _doorSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_doorSound);
 		_isOpened = true;
         _animator.SetBool("Open", true);
@@ -67,6 +69,7 @@ public class Door_2 : MonoBehaviour, IDoor
         if(!_isOpened) {
             return;
         }
+		_audioSource.volume = _doorSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_doorSound);
 		_isOpened = false;
         _animator.SetBool("Open", false);

--- a/Gravity Controller/Assets/Scripts/Environment/Door/Door_Boss.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/Door/Door_Boss.cs
@@ -17,6 +17,7 @@ public class Door_Boss : MonoBehaviour, IDoor
 
 	[SerializeField] private AudioSource _audioSource;
 	[SerializeField] private AudioClip _doorSound;
+	[SerializeField] private float _doorSoundMaxVolume = 1f;
 
 	private void Start() {
         _originalPosLeft = _doorLeft.transform.position;
@@ -27,6 +28,7 @@ public class Door_Boss : MonoBehaviour, IDoor
         if(_isOpened) {
             return;
         }
+		_audioSource.volume = _doorSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_doorSound);
 		_delta = 0;
         _isOpened = true;
@@ -36,6 +38,7 @@ public class Door_Boss : MonoBehaviour, IDoor
         if(!_isOpened) {
             return;
         }
+		_audioSource.volume = _doorSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_doorSound);
 		_delta = 0;
         _isOpened = false;

--- a/Gravity Controller/Assets/Scripts/Environment/Door/Door_Stage4.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/Door/Door_Stage4.cs
@@ -4,11 +4,9 @@ using UnityEngine;
 
 public class Door_Stage4 : MonoBehaviour, IDoor
 {
-	[SerializeField] private AudioSource _audioSource;
-	[SerializeField] private AudioClip _doorSound;
+
 	public void Open()
 	{
-		_audioSource.PlayOneShot(_doorSound);
 		// deleteCeils 안의 모든 자식 오브젝트 가져오기
 		foreach (Transform child in transform)
 		{
@@ -27,7 +25,6 @@ public class Door_Stage4 : MonoBehaviour, IDoor
 
 	public void Close()
 	{
-		_audioSource.PlayOneShot(_doorSound);
 		return;
 	}
 }

--- a/Gravity Controller/Assets/Scripts/Environment/Door/Door_Vert.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/Door/Door_Vert.cs
@@ -12,19 +12,23 @@ public class Door_Vert : MonoBehaviour, IDoor
     private Vector3 _targetPos;
     private AudioSource _audioSource;
 
-    private void Start() {
+	[SerializeField] private float _doorSoundMaxVolume = 1f;
+
+	private void Start() {
         _audioSource = GetComponent<AudioSource>();
         _originalPos = transform.position;
         _targetPos = transform.position + new Vector3(0, _moveDistance, 0);
     }
     public void Open() {
-        _audioSource.Play();
+		_audioSource.volume = _doorSoundMaxVolume * GameManager.Instance.GetSFXVolume();
+		_audioSource.Play();
         StopCoroutine(CloseDoor());
         StartCoroutine(OpenDoor());
         StartCoroutine(CloseTimer());
     }
     public void Close() {
-        _audioSource.Play();
+		_audioSource.volume = _doorSoundMaxVolume * GameManager.Instance.GetSFXVolume();
+		_audioSource.Play();
         StopCoroutine(OpenDoor());
         _doorLever.ResetLever();
         StartCoroutine(CloseDoor());

--- a/Gravity Controller/Assets/Scripts/GameManager.cs
+++ b/Gravity Controller/Assets/Scripts/GameManager.cs
@@ -12,6 +12,7 @@ public class GameManager : MonoBehaviour
 		if (Instance == null)
 		{
 			Instance = this;
+			DontDestroyOnLoad(gameObject);
 		}
 		else
 		{
@@ -38,6 +39,16 @@ public class GameManager : MonoBehaviour
 	public List<GameObject> GetActiveEnemies()
 	{
 		return _activeEnemies;
+	}
+
+	public float GetSFXVolume()
+	{
+		return 1f;
+	}
+
+	public float GetBGMVolume()
+	{
+		return 1f;
 	}
 }
 

--- a/Gravity Controller/Assets/Scripts/Player/PlayerController.cs
+++ b/Gravity Controller/Assets/Scripts/Player/PlayerController.cs
@@ -68,6 +68,13 @@ public class PlayerController : MonoBehaviour
 	[SerializeField] private AudioClip _localGravitySound;
 	private AudioSource _audioSource;
 
+	[SerializeField] private float _fireSoundMaxVolume = 1f;
+	[SerializeField] private float _reloadSoundMaxVolume = 1f;
+	[SerializeField] private float _hitSoundMaxVolume = 1f;
+	[SerializeField] private float _globalGravityUpSoundMaxVolume = 1f;
+	[SerializeField] private float _globalGravityDownSoundMaxVolume = 1f;
+	[SerializeField] private float _localGravitySoundMaxVolume = 1f;
+
 
 
 	void Start() {
@@ -122,6 +129,7 @@ public class PlayerController : MonoBehaviour
 	        {
 		        _isGravityLow = true;
 				_audioSource.clip = _globalGravityDownSound;
+				_audioSource.volume = _globalGravityDownSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 				_audioSource.Play();
 			}
 	        else if (_mouseInputWheel < -_wheelInputThreshold)
@@ -174,6 +182,7 @@ public class PlayerController : MonoBehaviour
         }
         if(_currentBullet-- > 0) {
             _isShootable = false;
+			_audioSource.volume = _fireSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 			_audioSource.PlayOneShot(_fireSound);
 			Debug.Log("fire");
             _gunGameObject.SendMessage("HandleRecoil", SendMessageOptions.DontRequireReceiver);
@@ -200,6 +209,7 @@ public class PlayerController : MonoBehaviour
     private void Reload() {
 		// Debug.Log("reloading...");
 		if (_isReloading) return;
+		_audioSource.volume = _reloadSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_reloadSound);
 		_isReloading = true;
         _isShootable = false;
@@ -241,6 +251,7 @@ public class PlayerController : MonoBehaviour
                 _isTargetable = false;
                 StartCoroutine(ReTargetable());
                 _currentEnergy -= _localEnergyCost;
+				_audioSource.volume = _localGravitySoundMaxVolume * GameManager.Instance.GetSFXVolume();
 				_audioSource.PlayOneShot(_localGravitySound);
 
 				// 여기서 피격된 대상의 오브젝트를 불러올 수 있음
@@ -267,6 +278,7 @@ public class PlayerController : MonoBehaviour
             return;
         }
         _currentEnergy -= _globalHighEnergyCost;
+		_audioSource.volume = _globalGravityUpSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_globalGravityUpSound);
 		_gunGameObject.SendMessage("HideGunOnSkill", SendMessageOptions.DontRequireReceiver);
 		
@@ -337,6 +349,7 @@ public class PlayerController : MonoBehaviour
             return;
         }
         Debug.Log("hit");
+		_audioSource.volume = _hitSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		_audioSource.PlayOneShot(_hitSound);
 		_currentHP--;
         UIManager.Instance.UpdateHP(_currentHP, _maxHP);

--- a/Gravity Controller/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Gravity Controller/Assets/Scripts/Player/PlayerMovement.cs
@@ -45,6 +45,7 @@ public class PlayerMovement : MonoBehaviour
 	[SerializeField] private AudioSource _footstepAudioSource;
 	[SerializeField] private AudioClip _footstepClip;
 	[SerializeField] private float _footstepInterval = 0.5f;
+	[SerializeField] private float _footstepMaxVolume = 1.0f;
 
 	private float _footstepTimer = 0f;
 	private bool _wasFootstepConditionMet = false;
@@ -190,6 +191,7 @@ public class PlayerMovement : MonoBehaviour
 			{
 				if (_footstepAudioSource != null && _footstepClip != null)
 				{
+					_footstepAudioSource.volume = _footstepMaxVolume * GameManager.Instance.GetSFXVolume();
 					_footstepAudioSource.PlayOneShot(_footstepClip);
 				}
 				_footstepTimer = 0f;

--- a/Gravity Controller/Assets/Scripts/UI/BGMManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/BGMManager.cs
@@ -18,6 +18,8 @@ public class BGMManager : MonoBehaviour
 	[SerializeField] private AudioClip _stage4BGM;
 	[SerializeField] private AudioClip _bossBGM;
 
+	[SerializeField] private float _BGMMaxVolume = 1f;
+
 	private Coroutine _currentFadeCoroutine;
 
 	private void Awake()
@@ -112,11 +114,11 @@ public class BGMManager : MonoBehaviour
 		while (elapsed < _fadeDuration)
 		{
 			float t = elapsed / _fadeDuration;
-			_audioSource.volume = Mathf.Lerp(0f, 1f, t);
+			_audioSource.volume = Mathf.Lerp(0f, _BGMMaxVolume * GameManager.Instance.GetBGMVolume(), t);
 			elapsed += Time.deltaTime;
 			yield return null;
 		}
-		_audioSource.volume = 1f;
+		_audioSource.volume = _BGMMaxVolume * GameManager.Instance.GetBGMVolume();
 
 		_currentFadeCoroutine = null;
 	}

--- a/Gravity Controller/Assets/Scripts/UI/GlitchUI.cs
+++ b/Gravity Controller/Assets/Scripts/UI/GlitchUI.cs
@@ -11,6 +11,7 @@ public class GlitchUI : MonoBehaviour
 
 	[SerializeField] private AudioSource _audioSource;    
 	[SerializeField] private AudioClip _glitchSound;
+	[SerializeField] private float _glitchSoundMaxVolume = 1f;
 
 	private bool _isGlitching = false;
 
@@ -34,6 +35,7 @@ public class GlitchUI : MonoBehaviour
 		{
 			if (_audioSource != null && _glitchSound != null)
 			{
+				_audioSource.volume = _glitchSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 				_audioSource.PlayOneShot(_glitchSound);
 			}
 


### PR DESCRIPTION
# PR Title 
[volume manipulation]

## Related Issue(s)
 1. 현재 메인 메뉴 씬에서 메인 카메라에 audiosource를 할당하지 않은 상태입니다.
 2. 스테이지3의 모든 적이 죽었을 때의 사운드가 필요합니다.
 
## PR Description
 각 코드에서 오디오 볼륨을 환경설정 시 설정한 볼륨값을 게임매니저를 통해 받아오는 방식으로 수정했습니다. 
게임매니저에서 씬이 바뀌어도 게임매니저가 사라지지 않도록 추가했습니다.
 
### Changes Included- [ 2 ] Added new feature(s)- [ ] Fixed identified bug(s)- [ ] Updated relevant documentation

### Screenshots (if UI changes were made)
Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)

### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.--

## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

## Additional Comments
