### PR TITLE
Feature/final

### DIFF
--- a/Gravity Controller/Assets/Blender/Animation/walking.controller
+++ b/Gravity Controller/Assets/Blender/Animation/walking.controller
@@ -1,5 +1,30 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-8787338224484294051
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2667823895257680363}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.625
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-8500486052116674535
 AnimatorState:
   serializedVersion: 6
@@ -13,6 +38,7 @@ AnimatorState:
   m_Transitions:
   - {fileID: 125101651579107035}
   - {fileID: -2252824385237234984}
+  - {fileID: -3421443255283820265}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -69,6 +95,7 @@ AnimatorState:
   m_Transitions:
   - {fileID: -4928355866197467299}
   - {fileID: -3233996256039743969}
+  - {fileID: 6071293790715944950}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -130,6 +157,31 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 0.8
   m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-3421443255283820265
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2667823895257680363}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.79310346
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -251,6 +303,7 @@ AnimatorState:
   m_Transitions:
   - {fileID: -744857988029795763}
   - {fileID: -7464215717301558900}
+  - {fileID: -8787338224484294051}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -351,6 +404,9 @@ AnimatorStateTransition:
   - m_ConditionMode: 2
     m_ConditionEvent: IsWalking
     m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: IsRunning
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -6619208085655020905}
   m_Solo: 0
@@ -392,7 +448,6 @@ AnimatorStateMachine:
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: 6677797154782116683}
-  - {fileID: 7747500349472394675}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -401,6 +456,31 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 50, y: 170, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -6619208085655020905}
+--- !u!1101 &6071293790715944950
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2667823895257680363}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &6491626228123943605
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -439,31 +519,6 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -1901588751782437455}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &7747500349472394675
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: Attack
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -2667823895257680363}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0

--- a/Gravity Controller/Assets/Scenes/GameOverScene.unity
+++ b/Gravity Controller/Assets/Scenes/GameOverScene.unity
@@ -336,7 +336,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: RESTART
+  m_Text: CONTINUE
 --- !u!222 &348357799
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Gravity Controller/Assets/Scenes/MainSettingUI.unity
+++ b/Gravity Controller/Assets/Scenes/MainSettingUI.unity
@@ -7123,7 +7123,7 @@ MonoBehaviour:
   - {fileID: 141143316}
   - {fileID: 773050754}
   - {fileID: 1361033028}
-  _defaultValues: 320000003200000032000000
+  _defaultValues: 640000006400000032000000
 --- !u!4 &1497681282
 Transform:
   m_ObjectHideFlags: 0

--- a/Gravity Controller/Assets/Scenes/MainSettingUI.unity
+++ b/Gravity Controller/Assets/Scenes/MainSettingUI.unity
@@ -1739,6 +1739,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 368277439}
   m_CullTransparentMesh: 1
+--- !u!1 &388378421
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 388378422}
+  - component: {fileID: 388378424}
+  - component: {fileID: 388378423}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &388378422
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 388378421}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 464339599}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &388378423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 388378421}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.57254905}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &388378424
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 388378421}
+  m_CullTransparentMesh: 1
 --- !u!1 &390810872
 GameObject:
   m_ObjectHideFlags: 0
@@ -1825,13 +1901,13 @@ MonoBehaviour:
       - m_Target: {fileID: 1073563510}
         m_TargetAssemblyTypeName: SceneChangeHandler, Assembly-CSharp
         m_MethodName: LoadGame
-        m_Mode: 5
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: UnitedScene
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!222 &390810875
@@ -1890,6 +1966,141 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 396283853}
   m_CullTransparentMesh: 0
+--- !u!1 &403358977
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 403358978}
+  - component: {fileID: 403358980}
+  - component: {fileID: 403358979}
+  - component: {fileID: 403358981}
+  m_Layer: 5
+  m_Name: no
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &403358978
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403358977}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.49999988, y: 0.49999988, z: 0.49999988}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 606912803}
+  - {fileID: 2063691842}
+  m_Father: {fileID: 914461767}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -113, y: -274}
+  m_SizeDelta: {x: 400, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &403358979
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403358977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.7169812, g: 0.7169812, b: 0.7169812, a: 1}
+    m_PressedColor: {r: 0.49056602, g: 0.49056602, b: 0.49056602, a: 1}
+    m_SelectedColor: {r: 0.7169812, g: 0.7169812, b: 0.7169812, a: 1}
+    m_DisabledColor: {r: 0.26415092, g: 0.26415092, b: 0.26415092, a: 0.11764706}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.05
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 21300000, guid: a4fde6e0b21dc224d813ee493157874f, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e5a390d359542f845bd18b3970c5eff3, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: a4fde6e0b21dc224d813ee493157874f, type: 3}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 403358981}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1073563510}
+        m_TargetAssemblyTypeName: SceneChangeHandler, Assembly-CSharp
+        m_MethodName: No
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!222 &403358980
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403358977}
+  m_CullTransparentMesh: 1
+--- !u!114 &403358981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403358977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9490196, g: 0.95686275, b: 0.98039216, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a8292d7c3170a7348accf3d85c0e7359, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &442898292
 GameObject:
   m_ObjectHideFlags: 0
@@ -1970,6 +2181,141 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 442898292}
   m_CullTransparentMesh: 1
+--- !u!1 &464339598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 464339599}
+  - component: {fileID: 464339601}
+  - component: {fileID: 464339600}
+  - component: {fileID: 464339602}
+  m_Layer: 5
+  m_Name: yes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &464339599
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464339598}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.49999988, y: 0.49999988, z: 0.49999988}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 388378422}
+  - {fileID: 700007259}
+  m_Father: {fileID: 914461767}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -323, y: -274}
+  m_SizeDelta: {x: 400, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &464339600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464339598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.7169812, g: 0.7169812, b: 0.7169812, a: 1}
+    m_PressedColor: {r: 0.49056602, g: 0.49056602, b: 0.49056602, a: 1}
+    m_SelectedColor: {r: 0.7169812, g: 0.7169812, b: 0.7169812, a: 1}
+    m_DisabledColor: {r: 0.26415092, g: 0.26415092, b: 0.26415092, a: 0.11764706}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.05
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 21300000, guid: a4fde6e0b21dc224d813ee493157874f, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e5a390d359542f845bd18b3970c5eff3, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: a4fde6e0b21dc224d813ee493157874f, type: 3}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 464339602}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1073563510}
+        m_TargetAssemblyTypeName: SceneChangeHandler, Assembly-CSharp
+        m_MethodName: Yes
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!222 &464339601
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464339598}
+  m_CullTransparentMesh: 1
+--- !u!114 &464339602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464339598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9490196, g: 0.95686275, b: 0.98039216, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a8292d7c3170a7348accf3d85c0e7359, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &505394524
 GameObject:
   m_ObjectHideFlags: 0
@@ -2277,6 +2623,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 600849554}
   m_CullTransparentMesh: 1
+--- !u!1 &606912802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 606912803}
+  - component: {fileID: 606912805}
+  - component: {fileID: 606912804}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &606912803
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 606912802}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 403358978}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &606912804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 606912802}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.57254905}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &606912805
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 606912802}
+  m_CullTransparentMesh: 1
 --- !u!1 &623110910
 GameObject:
   m_ObjectHideFlags: 0
@@ -2543,6 +2965,86 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 691345104}
   m_CullTransparentMesh: 0
+--- !u!1 &700007258
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 700007259}
+  - component: {fileID: 700007261}
+  - component: {fileID: 700007260}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &700007259
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 700007258}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 464339599}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000030517578, y: -0.0000038146973}
+  m_SizeDelta: {x: -200, y: -50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &700007260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 700007258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0d321ad12fe3d4391b506737af0972d1, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: YES
+--- !u!222 &700007261
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 700007258}
+  m_CullTransparentMesh: 1
 --- !u!1 &700856030
 GameObject:
   m_ObjectHideFlags: 0
@@ -3974,6 +4476,87 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 890843127}
   m_CullTransparentMesh: 1
+--- !u!1 &914461766
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 914461767}
+  - component: {fileID: 914461769}
+  - component: {fileID: 914461768}
+  m_Layer: 5
+  m_Name: Alert
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &914461767
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 914461766}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1728957591}
+  - {fileID: 1438760504}
+  - {fileID: 1294592316}
+  - {fileID: 464339599}
+  - {fileID: 403358978}
+  m_Father: {fileID: 1103953188}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 436.5723, y: 308.8107}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &914461768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 914461766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.21960784, g: 0.21960784, b: 0.21960784, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a4fde6e0b21dc224d813ee493157874f, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &914461769
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 914461766}
+  m_CullTransparentMesh: 1
 --- !u!1 &958002129
 GameObject:
   m_ObjectHideFlags: 0
@@ -4907,6 +5490,7 @@ MonoBehaviour:
   startButton: {fileID: 390810874}
   _textCanvas: {fileID: 1103953184}
   _loadingCanvas: {fileID: 2083025910}
+  _alert: {fileID: 914461766}
 --- !u!4 &1073563511
 Transform:
   m_ObjectHideFlags: 0
@@ -5201,6 +5785,7 @@ RectTransform:
   m_Children:
   - {fileID: 1916638613}
   - {fileID: 1865490322}
+  - {fileID: 914461767}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6061,6 +6646,83 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1258218482}
   m_CullTransparentMesh: 1
+--- !u!1 &1294592315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1294592316}
+  - component: {fileID: 1294592318}
+  - component: {fileID: 1294592317}
+  m_Layer: 5
+  m_Name: TextPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1294592316
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1294592315}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1815536674}
+  m_Father: {fileID: 914461767}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00092316, y: 31.501}
+  m_SizeDelta: {x: 436.57, y: 245.81}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1294592317
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1294592315}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.21960784, g: 0.21960784, b: 0.21960784, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a4fde6e0b21dc224d813ee493157874f, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1294592318
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1294592315}
+  m_CullTransparentMesh: 1
 --- !u!1 &1303085836
 GameObject:
   m_ObjectHideFlags: 0
@@ -6844,6 +7506,82 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1438760503
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1438760504}
+  - component: {fileID: 1438760506}
+  - component: {fileID: 1438760505}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1438760504
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1438760503}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 914461767}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1438760505
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1438760503}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.69411767}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1438760506
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1438760503}
+  m_CullTransparentMesh: 1
 --- !u!1 &1476337022
 GameObject:
   m_ObjectHideFlags: 0
@@ -7930,6 +8668,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1727846444}
   m_CullTransparentMesh: 0
+--- !u!1 &1728957590
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1728957591}
+  - component: {fileID: 1728957593}
+  - component: {fileID: 1728957592}
+  m_Layer: 5
+  m_Name: PreventClick
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1728957591
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728957590}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 914461767}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.51460266, y: -0.43580627}
+  m_SizeDelta: {x: 369.0777, y: 149.5168}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1728957592
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728957590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1728957593
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728957590}
+  m_CullTransparentMesh: 1
 --- !u!1 &1762627302
 GameObject:
   m_ObjectHideFlags: 0
@@ -8247,6 +9061,86 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1804924099}
+  m_CullTransparentMesh: 1
+--- !u!1 &1815536673
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1815536674}
+  - component: {fileID: 1815536676}
+  - component: {fileID: 1815536675}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1815536674
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1815536673}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1294592316}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 350.55, y: 198.3676}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1815536675
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1815536673}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0d321ad12fe3d4391b506737af0972d1, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &1815536676
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1815536673}
   m_CullTransparentMesh: 1
 --- !u!1 &1824039026
 GameObject:
@@ -9410,6 +10304,86 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e75ee300469730b479630420c750a0f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2063691841
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2063691842}
+  - component: {fileID: 2063691844}
+  - component: {fileID: 2063691843}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2063691842
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063691841}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 403358978}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.000011444092}
+  m_SizeDelta: {x: -200, y: -50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2063691843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063691841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0d321ad12fe3d4391b506737af0972d1, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: NO
+--- !u!222 &2063691844
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063691841}
+  m_CullTransparentMesh: 1
 --- !u!1 &2074340059
 GameObject:
   m_ObjectHideFlags: 0
@@ -9818,13 +10792,13 @@ MonoBehaviour:
       - m_Target: {fileID: 1073563510}
         m_TargetAssemblyTypeName: SceneChangeHandler, Assembly-CSharp
         m_MethodName: ContinueGame
-        m_Mode: 5
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: UnitedScene
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!222 &2140164249

--- a/Gravity Controller/Assets/Scenes/MainSettingUI.unity
+++ b/Gravity Controller/Assets/Scenes/MainSettingUI.unity
@@ -4883,6 +4883,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1073563511}
   - component: {fileID: 1073563510}
+  - component: {fileID: 1073563512}
   m_Layer: 0
   m_Name: ButtonManager
   m_TagString: Untagged
@@ -4921,6 +4922,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1073563512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1073563509}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 24b813f681c441b4088494b9fbdeb2bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1080525822
 GameObject:
   m_ObjectHideFlags: 0
@@ -8214,7 +8227,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 148876821}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1073563512}
+        m_TargetAssemblyTypeName: Exit, Assembly-CSharp
+        m_MethodName: Quit
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!222 &1804924102
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Gravity Controller/Assets/Scripts/Enemy/Spawner/DelayedSpawner.cs
+++ b/Gravity Controller/Assets/Scripts/Enemy/Spawner/DelayedSpawner.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using static UnityEditor.Experimental.GraphView.GraphView;
 
 public class DelayedSpawner : MonoBehaviour, IEnemyFactory
 {

--- a/Gravity Controller/Assets/Scripts/Enemy/Spawner/Spawner.cs
+++ b/Gravity Controller/Assets/Scripts/Enemy/Spawner/Spawner.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using static UnityEditor.Experimental.GraphView.GraphView;
 
 public class Spawner : MonoBehaviour, IEnemyFactory
 {

--- a/Gravity Controller/Assets/Scripts/Environment/CoreController.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/CoreController.cs
@@ -154,6 +154,18 @@ public class CoreController : MonoBehaviour, IInteractable
 			RestoreCore(i);
 		}
 
+		for (int i = 0; i < _stageLights.Count; i++)
+		{
+			if (i == stage - 1)
+			{
+				_stageLights[i].intensity = 10f;
+			}
+			else
+			{
+				_stageLights[i].intensity = 0f;
+			}
+		}
+
 		_current_stage = stage + 1;
 	}
 }

--- a/Gravity Controller/Assets/Scripts/Environment/CoreController.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/CoreController.cs
@@ -58,7 +58,6 @@ public class CoreController : MonoBehaviour, IInteractable
 			StartCoroutine(GlobalLightOn());
         }
 
-        StageManager.Instance.LoadStage(_current_stage);
         RestoreCore(_current_stage - 1);
         StartCoroutine(UIManager.Instance.ShowStageIntro(_current_stage - 1));
         _player.UpdateStage(_current_stage + 1);
@@ -75,8 +74,15 @@ public class CoreController : MonoBehaviour, IInteractable
 		        _stageLights[i].intensity = 0f;
 	        }
         }
-		_current_stage++;
 
+		StartCoroutine(RemainingProcess());
+	}
+
+	private IEnumerator RemainingProcess()
+	{
+		yield return new WaitForSeconds(0f);
+		StageManager.Instance.LoadStage(_current_stage);
+		_current_stage++;
 		Autosave.SaveGameSave(true, _current_stage);
     }
     

--- a/Gravity Controller/Assets/Scripts/Environment/CoreInteraction.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/CoreInteraction.cs
@@ -33,6 +33,8 @@ public class CoreInteraction : MonoBehaviour, IInteractable
    private bool _isInteractable = true;
    private bool _hasEnemiesCleared = false; // 적 처치 완료 여부
 
+	public bool IsEmergency = false;
+
 	[Header("Audio")]
 	[SerializeField] private AudioSource _audioSource;
 	[SerializeField] private AudioClip _timeOutSound;
@@ -71,6 +73,8 @@ public class CoreInteraction : MonoBehaviour, IInteractable
             _coreLight.enabled = true;
          }
 
+		 IsEmergency = true;
+
 		 _audioSource.volume = _coreSoundMaxVolume * GameManager.Instance.GetSFXVolume();
 		 _audioSource.PlayOneShot(_coreSound);
 
@@ -90,6 +94,8 @@ public class CoreInteraction : MonoBehaviour, IInteractable
             forceFieldMaterial.EnableKeyword("_EMISSION");
             forceFieldMaterial.SetColor("_EmissionColor", Color.white); 
          }
+
+			IsEmergency = false;
 
 		 _isInteractable = false; 
 		 _audioSource.volume = _coreSoundMaxVolume * GameManager.Instance.GetSFXVolume();

--- a/Gravity Controller/Assets/Scripts/Environment/PlatformController.cs
+++ b/Gravity Controller/Assets/Scripts/Environment/PlatformController.cs
@@ -86,7 +86,10 @@ public class PlatformController : MonoBehaviour
 
 		foreach (ParticleSystem dustParticle in _dust)
 		{
-			var mult = dustParticle.main.startSpeedMultiplier;
+			var main = dustParticle.main;
+			main.startColor = IsEmergency() ? (Color) new Color32(0x60, 0x37, 0x3e, 0xff) : (Color) new Color32(0x67, 0x63, 0x5d, 0xff);
+
+			var mult = main.startSpeedMultiplier;
 			var em = dustParticle.emission;
 			mult = _unitSpeed * (7 + _targetY - transform.position.y);
 			em.rateOverTime = _unitParticleRate * Mathf.Pow((7 + _targetY - transform.position.y), _emissionPower);
@@ -99,9 +102,16 @@ public class PlatformController : MonoBehaviour
 			
 			var sparkle = transform.parent.Find("SparkleDust");
 			sparkle.position = newPosition;
+			var main = sparkle.GetComponent<ParticleSystem>().main;
+			main.startColor = IsEmergency() ? (Color)new Color32(0x60, 0x37, 0x3e, 0xff) : (Color)new Color32(0x67, 0x63, 0x5d, 0xff);
 			sparkle.gameObject.SetActive(true);
 
 			gameObject.SetActive(false);
 		}
+	}
+
+	private bool IsEmergency()
+	{
+		return GameObject.Find("Stage_third").transform.Find("FUSION_CORE").GetComponent<CoreInteraction>().IsEmergency;
 	}
 }

--- a/Gravity Controller/Assets/Scripts/GameManager.cs
+++ b/Gravity Controller/Assets/Scripts/GameManager.cs
@@ -21,6 +21,8 @@ public class GameManager : MonoBehaviour
 		{
 			Destroy(gameObject);
 		}
+
+		Cursor.visible = false;
 	}
 
 	public void RegisterEnemy(GameObject enemy)

--- a/Gravity Controller/Assets/Scripts/GameManager.cs
+++ b/Gravity Controller/Assets/Scripts/GameManager.cs
@@ -7,6 +7,8 @@ public class GameManager : MonoBehaviour
 	public static GameManager Instance { get; private set; }
 	private List<GameObject> _activeEnemies = new List<GameObject>();
 	private int _enemyNumber = 0;
+	private float _sfxVolume = 1f;
+	private float _bgmVolume = 1f;
 
 	private void Awake()
 	{
@@ -48,12 +50,22 @@ public class GameManager : MonoBehaviour
 
 	public float GetSFXVolume()
 	{
-		return 1f;
+		return _sfxVolume;
+	}
+
+	public void SetSFXVolume(float vol)
+	{
+		_sfxVolume = vol;
 	}
 
 	public float GetBGMVolume()
 	{
-		return 1f;
+		return _bgmVolume;
+	}
+
+	public void SetBGMVolume(float vol)
+	{
+		_bgmVolume = vol;
 	}
 
 	public bool IsClear()

--- a/Gravity Controller/Assets/Scripts/Player/PlayerController.cs
+++ b/Gravity Controller/Assets/Scripts/Player/PlayerController.cs
@@ -367,5 +367,8 @@ public class PlayerController : MonoBehaviour
 	    _currentHP = _maxHP;
 	    _currentBullet = _maxBullet;
 	    _currentEnergy = _maxEnergy;
+
+		UIManager.Instance.UpdateHP(_maxHP, _maxHP);
+		UIManager.Instance.UpdateBullet(_maxBullet, _maxBullet);
 	}
 }

--- a/Gravity Controller/Assets/Scripts/UI/BGMManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/BGMManager.cs
@@ -29,7 +29,6 @@ public class BGMManager : MonoBehaviour
 		if (Instance == null)
 		{
 			Instance = this;
-			DontDestroyOnLoad(gameObject);
 		}
 		else
 		{

--- a/Gravity Controller/Assets/Scripts/UI/BGMManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/BGMManager.cs
@@ -18,7 +18,7 @@ public class BGMManager : MonoBehaviour
 	[SerializeField] private AudioClip _stage4BGM;
 	[SerializeField] private AudioClip _bossBGM;
 
-	[SerializeField] private float _BGMMaxVolume = 1f;
+	[SerializeField] private float _bgmMaxVolume = 1f;
 
 	private Coroutine _currentFadeCoroutine;
 
@@ -125,11 +125,11 @@ public class BGMManager : MonoBehaviour
 		while (elapsed < _fadeDuration)
 		{
 			float t = elapsed / _fadeDuration;
-			_audioSource.volume = Mathf.Lerp(0f, _BGMMaxVolume * GameManager.Instance.GetBGMVolume(), t);
+			_audioSource.volume = Mathf.Lerp(0f, _bgmMaxVolume * GameManager.Instance.GetBGMVolume(), t);
 			elapsed += Time.deltaTime;
 			yield return null;
 		}
-		_audioSource.volume = _BGMMaxVolume * GameManager.Instance.GetBGMVolume();
+		_audioSource.volume = _bgmMaxVolume * GameManager.Instance.GetBGMVolume();
 
 		_currentFadeCoroutine = null;
 	}

--- a/Gravity Controller/Assets/Scripts/UI/Exit.cs
+++ b/Gravity Controller/Assets/Scripts/UI/Exit.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Exit : MonoBehaviour
+{
+   public void Quit()
+	{
+		Application.Quit();
+	}
+}

--- a/Gravity Controller/Assets/Scripts/UI/Exit.cs.meta
+++ b/Gravity Controller/Assets/Scripts/UI/Exit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24b813f681c441b4088494b9fbdeb2bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
@@ -35,11 +35,13 @@ public class GameOverManager : MonoBehaviour
 
 	public void RestartGame()
 	{
+		Destroy(GameManager.Instance.gameObject);
 		SceneManager.LoadScene("FinalGameScene");
 	}
 
 	public void GoToMainMenu()
 	{
+		Destroy(GameManager.Instance.gameObject);
 		SceneManager.LoadScene("MainSettingUI");
 	}
 }

--- a/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
@@ -58,7 +58,10 @@ public class GameOverManager : MonoBehaviour
 		}
 
 		GameObject.Find("Video Canvas").transform.GetChild(0).gameObject.GetComponent<VideoEndHandler>().EndVideo();
-		GameObject.Find("ButtonManager").GetComponent<SceneChangeHandler>().ContinueGame("UnitedScene");
+		
+		var sceneChangeHandler = GameObject.Find("ButtonManager").GetComponent<SceneChangeHandler>();
+		sceneChangeHandler.FetchSaves();
+		sceneChangeHandler.ContinueGameWithoutAlert();
 
 		Destroy(gameObject);
 	}

--- a/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
@@ -36,7 +36,7 @@ public class GameOverManager : MonoBehaviour
 	public void RestartGame()
 	{
 		Destroy(GameManager.Instance.gameObject);
-		SceneManager.LoadScene("FinalGameScene");
+		SceneManager.LoadScene("UnitedScene");
 	}
 
 	public void GoToMainMenu()

--- a/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
@@ -10,6 +10,8 @@ public class GameOverManager : MonoBehaviour
 
 	void Start()
 	{
+		DontDestroyOnLoad(gameObject);
+
 		_buttonsCanvasGroup.alpha = 0f;
 		_buttonsCanvasGroup.interactable = false;
 		_buttonsCanvasGroup.blocksRaycasts = false;
@@ -36,12 +38,39 @@ public class GameOverManager : MonoBehaviour
 	public void RestartGame()
 	{
 		Destroy(GameManager.Instance.gameObject);
-		SceneManager.LoadScene("UnitedScene");
+		StartCoroutine(ContinueGame());
 	}
 
 	public void GoToMainMenu()
 	{
 		Destroy(GameManager.Instance.gameObject);
-		SceneManager.LoadScene("MainSettingUI");
+		StartCoroutine(LoadMainMenu());
+	}
+
+	IEnumerator ContinueGame()
+	{
+		AsyncOperation asyncLoad = SceneManager.LoadSceneAsync("MainSettingUI");
+		while (!asyncLoad.isDone)
+		{
+			yield return null;
+		}
+
+		GameObject.Find("Video Canvas").transform.GetChild(0).gameObject.GetComponent<VideoEndHandler>().EndVideo();
+		GameObject.Find("ButtonManager").GetComponent<SceneChangeHandler>().ContinueGame("UnitedScene");
+
+		Destroy(gameObject);
+	}
+
+	IEnumerator LoadMainMenu()
+	{
+		AsyncOperation asyncLoad = SceneManager.LoadSceneAsync("MainSettingUI");
+		while (!asyncLoad.isDone)
+		{
+			yield return null;
+		}
+
+		GameObject.Find("Video Canvas").transform.GetChild(0).gameObject.GetComponent<VideoEndHandler>().EndVideo();
+
+		Destroy(gameObject);
 	}
 }

--- a/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/GameOverManager.cs
@@ -16,6 +16,8 @@ public class GameOverManager : MonoBehaviour
 		_buttonsCanvasGroup.interactable = false;
 		_buttonsCanvasGroup.blocksRaycasts = false;
 
+		Cursor.visible = true;
+
 		StartCoroutine(FadeInButtons());
 	}
 

--- a/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
+++ b/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
@@ -60,9 +60,11 @@ public class SceneChangeHandler : MonoBehaviour
 		GameObject summonPoint = null;
 		if (_gameSave.atLobby) { 
 			summonPoint = GameObject.Find("Summon Point").transform.GetChild(0).gameObject;
+			BGMManager.Instance.SetStageBGM(0);
 		}
 		else {
 			summonPoint = GameObject.Find("Summon Point").transform.GetChild(1).GetChild(_gameSave.stage - 1).gameObject;
+			BGMManager.Instance.SetStageBGM(_gameSave.stage);
 		}
 		player.transform.position = summonPoint.transform.position;
 		player.transform.rotation = summonPoint.transform.rotation;

--- a/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
+++ b/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
@@ -80,9 +80,10 @@ public class SceneChangeHandler : MonoBehaviour
 
 	private void InitSettingsSave()
 	{
-		// TODO Initial settings
 		var player = GameObject.Find("Player");
 		player.GetComponent<PlayerMovement>().SetSensitivityMultiplier(_settingsSave.sensitivity);
+		GameManager.Instance.SetBGMVolume(_settingsSave.backGroundVolume/100f);
+		GameManager.Instance.SetSFXVolume(_settingsSave.effectVolume/100f);
 	}
 
 	IEnumerator LoadGameCoroutine(string scene)

--- a/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
+++ b/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
@@ -84,6 +84,10 @@ public class SceneChangeHandler : MonoBehaviour
 		player.GetComponent<PlayerMovement>().SetSensitivityMultiplier(_settingsSave.sensitivity);
 		GameManager.Instance.SetBGMVolume(_settingsSave.backGroundVolume/100f);
 		GameManager.Instance.SetSFXVolume(_settingsSave.effectVolume/100f);
+
+		// (Temporary) Set initial position
+		GameObject summonPoint = GameObject.Find("Summon Point").transform.GetChild(1).GetChild(0).gameObject;
+		player.transform.position = summonPoint.transform.position;
 	}
 
 	IEnumerator LoadGameCoroutine(string scene)

--- a/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
+++ b/Gravity Controller/Assets/Scripts/UI/SceneChangeHandler.cs
@@ -115,8 +115,8 @@ public class SceneChangeHandler : MonoBehaviour
 		}
 		//var mainMenu = SceneManager.GetActiveScene();
 		//SceneManager.SetActiveScene(SceneManager.GetSceneByName(scene));
-		InitGameSave();
 		InitSettingsSave();
+		InitGameSave();
 		//SceneManager.UnloadSceneAsync(mainMenu);
 
 		Destroy(_loadingCanvas);

--- a/Gravity Controller/Assets/Scripts/UI/UIManager.cs
+++ b/Gravity Controller/Assets/Scripts/UI/UIManager.cs
@@ -243,15 +243,18 @@ public class UIManager : MonoBehaviour
 
 		_stageIntroBackground.SetActive(true);
 
+		Time.timeScale = 0f;
+
 		// Enter 키 입력 대기
 		bool enterPressed = false;
 		while (!enterPressed)
 		{
 			if (Input.GetKeyDown(KeyCode.T))
 			{
+				Time.timeScale = 1f;
 				enterPressed = true;
 			}
-			yield return null;
+			yield return new WaitForSeconds(0f);
 		}
 
 		_stageIntroBackground.SetActive(false);

--- a/Gravity Controller/Assets/Scripts/UI/VideoEndHandler.cs
+++ b/Gravity Controller/Assets/Scripts/UI/VideoEndHandler.cs
@@ -7,17 +7,17 @@ public class VideoEndHandler : MonoBehaviour
 {
 	public VideoPlayer videoPlayer;
 	public GameObject uiGroup;
-	private CanvasGroup canvasGroup;
+	private CanvasGroup _canvasGroup;
 	public float fadeDuration = 1.0f;
 	void Start()
 	{
-		canvasGroup = uiGroup.GetComponent<CanvasGroup>();
-		if (canvasGroup == null)
+		_canvasGroup = uiGroup.GetComponent<CanvasGroup>();
+		if (_canvasGroup == null)
 		{
-			canvasGroup = uiGroup.AddComponent<CanvasGroup>();
+			_canvasGroup = uiGroup.AddComponent<CanvasGroup>();
 		}
 
-		canvasGroup.alpha = 0f;
+		_canvasGroup.alpha = 0f;
 		uiGroup.SetActive(false);
 
 		videoPlayer.loopPointReached += OnVideoEnd;
@@ -26,7 +26,7 @@ public class VideoEndHandler : MonoBehaviour
 	void OnVideoEnd(VideoPlayer vp)
 	{
 		uiGroup.SetActive(true);
-		StartCoroutine(FadeInCanvasGroup(canvasGroup, fadeDuration));
+		StartCoroutine(FadeInCanvasGroup(_canvasGroup, fadeDuration));
 	}
 
 	private IEnumerator FadeInCanvasGroup(CanvasGroup cg, float duration)
@@ -41,5 +41,11 @@ public class VideoEndHandler : MonoBehaviour
 		}
 
 		cg.alpha = 1f; 
+	}
+
+	public void EndVideo()
+	{
+		videoPlayer.Stop();
+		OnVideoEnd(videoPlayer);
 	}
 }

--- a/Gravity Controller/Assets/Scripts/UI/VideoEndHandler.cs
+++ b/Gravity Controller/Assets/Scripts/UI/VideoEndHandler.cs
@@ -45,7 +45,9 @@ public class VideoEndHandler : MonoBehaviour
 
 	public void EndVideo()
 	{
-		videoPlayer.Stop();
+		//videoPlayer.Stop();
+		videoPlayer.time = 30f;
+		videoPlayer.Pause();
 		OnVideoEnd(videoPlayer);
 	}
 }


### PR DESCRIPTION
# PR Title [Polishing & Bugfix]

## PR Description
- Naming convention에 맞지 않는 코드를 일부 수정했습니다.
- 프리팹으로 만들어만 두고 씬에 추가하지 않았던 Summon Point 프리팹을 추가했습니다. (이전 커밋의 변경사항이 롤백됨)
- 컴파일 오류로 인해 빌드가 되지 않는 문제를 해결했습니다. 사용하지 않는 패키지가 문제를 일으키고 있었습니다.
- 게임 진인 시 볼륨 설정을 GameManager에 넘겨주도록 했습니다. 기본값도 100%도 바꾸었습니다.
- 보스 스테이지를 비활성화했습니다.
- 플레이어 피격 시 효과를 적용했습니다. (적용 누락)
- 장애물을 뚫고 지나가는 적의 위치를 바꾸었습니다.
- 플레이어의 첫 소환 지점을 코드로 지정해 주었습니다. (Summon Point 이용)
- 스킬 습득 등의 메시지창이 뜰 때 게임이 멈추도록 했습니다. 스테이지 4의 느린 로딩 속도를 감춥니다.
- 로비의 코어와 상호작용할 시 UI를 업데이트합니다. (체력, 잔탄 회복)
- 스테이지 3에서, 발판의 파티클이 상황에 따라 색을 바꿉니다.
- 게임오버 시 BGMManager가 남아 있으면서 소리를 내는 문제를 해결했습니다. 재도전/메인메뉴 버튼 클릭 시 GameManager도 없애도록 했습니다.
- 게임오버 화면의 재시작 버튼을 '재도전' 버튼으로 바꾸었습니다 (CONTINUE). 기능도 구현했습니다.
- 저장된 게임을 불러올 때 로비 음악을 재생합니다.
- 다음으로 공략할 스테이지를 표시하는 광원의 위치를 조정했습니다. 저장된 게임을 불러올 때 알맞은 불이 켜지도록 합니다.
- 게임오버 후 메인메뉴로 진입할 때 비디오를 재생하지 않습니다.
- 게임 진입 시 커서를 보이지 않게 합니다. 게임오버 시 커서가 다시 보이도록 합니다.
- 메인 메뉴의 EXIT 버튼의 기능을 구현했습니다.
- START/CONTINUE 버튼을 클릭했을 때, 세이브와 관련한 이슈 발생 시 알림창을 띄워 의사를 묻습니다.
- 보행형 로봇의 animation conroller를 수정했습니다. 배회 중 플레이어를 발견했을 때 Idle state로 움직이는 현상과 죽었음에도 공격 애니메이션이 재생되는 현상을 수정했습니다.
- 잔탄 관련 UI가 화면을 키웠을 때 어긋나는 오류를 발견했습니다. 모든 요소의 피벗을 중앙에 두어 어긋나지 않도록 했습니다.

### Changes Included- [ 9 ] Added new feature(s)- [ 13 ] Fixed identified bug(s)

### Notes for Reviewer
코드 수정이 그리 많지는 않아서, 코드 상의 오류가 있을 것 같지는 않습니다.
대부분의 기능은 직접 테스트해 보았습니다.
다만, 스테이지 앞 광원의 경우 작업자가 게임을 못해서 스테이지 4를 클리어하지 못하는 관계로 보스 스테이지에 제대로 적용되었는지 확인하지 못했습니다.

저 열심히 했어요 아시죠...
8주간의 개발 모두 수고 많으셨습니다.

## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
